### PR TITLE
Specify Aqua appearance (vs Dark Aqua).

### DIFF
--- a/Sources/Resources/Mac/Base.lproj/FRMacFeedbackWindowController.xib
+++ b/Sources/Resources/Mac/Base.lproj/FRMacFeedbackWindowController.xib
@@ -41,7 +41,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Feedback" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Feedback Window">
+        <window title="Feedback" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" appearanceType="aqua" animationBehavior="default" id="5" userLabel="Feedback Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="480" y="88" width="600" height="640"/>


### PR DESCRIPTION
Rather than attempting to support Dark Aqua mode on Mac, simply specify that the Feedback window should be in standard (light) Aqua mode.